### PR TITLE
Corrected IB syntax case-sensitivity for PCSG00987

### DIFF
--- a/patchlist.txt
+++ b/patchlist.txt
@@ -2118,7 +2118,7 @@
 
 # Blue Reflection: Maboroshi ni Mau - Shoujo no Ken [JP 1.05]
 [PCSG00987, eboot.bin, 0xB2361C99]
-@ib
+@IB
 0:0x31716C t2_mov(1, 0, align(ib_w, 32))
 0:0x317172 t2_mov(1, 0, ib_h)
 


### PR DESCRIPTION
For some reason, the `@IB` line for `PCSG00987` was incorrectly written in all-lowercase as `@ib`. This is the only entry in the entire file with this error.

This change also corrects an issue where VitaGrafix Configurator will fail to properly expose configuration options for the internal resolution for `PCSG00987`. Not sure whether or not VitaGrafix itself is able to deal with this, as I don't own the game in question (… well, at least not on Vita. I own it on PS4 ;P)